### PR TITLE
Bold 속성 신설 및 bbox 로직 수정

### DIFF
--- a/pdfminer/converter.py
+++ b/pdfminer/converter.py
@@ -38,7 +38,7 @@ from .layout import LTTextLine
 from .pdfdevice import PDFTextDevice
 from .pdffont import PDFFont
 from .pdffont import PDFUnicodeNotDefined
-from .pdfinterp import PDFGraphicState, PDFResourceManager
+from .pdfinterp import PDFGraphicState, PDFResourceManager, PDFTextState # 으로 수정
 from .pdfpage import PDFPage
 from .pdftypes import PDFStream
 from .utils import AnyIO, Point, Matrix, Rect, PathSegment, make_compat_str
@@ -227,6 +227,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
         cid: int,
         ncs: PDFColorSpace,
         graphicstate: PDFGraphicState,
+        textstate: PDFTextState
     ) -> float:
         try:
             text = font.to_unichr(cid)
@@ -246,6 +247,7 @@ class PDFLayoutAnalyzer(PDFTextDevice):
             textdisp,
             ncs,
             graphicstate,
+            textstate
         )
         self.cur_item.add(item)
         return item.adv

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -19,6 +19,7 @@ from .pdfcolor import PDFColorSpace
 from .pdffont import PDFFont
 from .pdfinterp import Color
 from .pdfinterp import PDFGraphicState
+from .pdfinterp import PDFTextState
 from .pdftypes import PDFStream
 from .utils import INF, PathSegment
 from .utils import LTComponentT
@@ -32,6 +33,7 @@ from .utils import fsplit
 from .utils import get_bound
 from .utils import matrix2str
 from .utils import uniq
+from .utils import is_bold
 
 logger = logging.getLogger(__name__)
 
@@ -369,6 +371,7 @@ class LTChar(LTComponent, LTText):
         textdisp: Union[float, Tuple[Optional[float], float]],
         ncs: PDFColorSpace,
         graphicstate: PDFGraphicState,
+        textstate: PDFTextState
     ) -> None:
         LTText.__init__(self)
         self._text = text
@@ -377,6 +380,8 @@ class LTChar(LTComponent, LTText):
         self.ncs = ncs
         self.graphicstate = graphicstate
         self.adv = textwidth * fontsize * scaling
+        self.bold = is_bold(self.fontname, textstate.render)
+
         # compute the boundary rectangle.
         if font.is_vertical():
             # vertical

--- a/pdfminer/layout.py
+++ b/pdfminer/layout.py
@@ -391,9 +391,9 @@ class LTChar(LTComponent, LTText):
             bbox_upper_right = (-vx + fontsize, vy + rise)
         else:
             # horizontal
-            descent = font.get_descent() * fontsize
-            bbox_lower_left = (0, descent + rise)
-            bbox_upper_right = (self.adv, descent + rise + fontsize)
+            bbox_lower_left = (0, rise)
+            bbox_upper_right = (self.adv, rise + fontsize)
+            
         (a, b, c, d, e, f) = self.matrix
         self.upright = 0 < a * d * scaling and b * c <= 0
         (x0, y0) = apply_matrix_pt(self.matrix, bbox_lower_left)

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -161,7 +161,7 @@ class PDFTextDevice(PDFDevice):
         dxscale: float,
         ncs: PDFColorSpace,
         graphicstate: "PDFGraphicState",
-        textstate: PDFTextState, # 수정 부분
+        textstate: "PDFTextState", # 수정 부분
     ) -> Point:
         (x, y) = pos
         needcharspace = False

--- a/pdfminer/pdfdevice.py
+++ b/pdfminer/pdfdevice.py
@@ -128,6 +128,7 @@ class PDFTextDevice(PDFDevice):
                 dxscale,
                 ncs,
                 graphicstate,
+                textstate
             )
         else:
             textstate.linematrix = self.render_string_horizontal(
@@ -143,6 +144,7 @@ class PDFTextDevice(PDFDevice):
                 dxscale,
                 ncs,
                 graphicstate,
+                textstate
             )
 
     def render_string_horizontal(
@@ -159,6 +161,7 @@ class PDFTextDevice(PDFDevice):
         dxscale: float,
         ncs: PDFColorSpace,
         graphicstate: "PDFGraphicState",
+        textstate: PDFTextState, # 수정 부분
     ) -> Point:
         (x, y) = pos
         needcharspace = False
@@ -179,6 +182,7 @@ class PDFTextDevice(PDFDevice):
                         cid,
                         ncs,
                         graphicstate,
+                        textstate, # 수정 부분
                     )
                     if cid == 32 and wordspace:
                         x += wordspace

--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -802,3 +802,13 @@ def format_int_alpha(value: int) -> str:
 
     result.reverse()
     return "".join(result)
+
+
+def is_bold(fontname: str, render_state: bool) -> bool:
+    if 'bold' in fontname or 'Bold' in fontname: # 폰트 이름으로 찾기
+        return True
+    else:
+        if render_state == 2: # Tr로 찾기
+            return True
+        else:
+            return False


### PR DESCRIPTION
**Pull request**

1. bbox의 upper_right와 lower_left를 descent를 제거하여 반영.
2. LTChar에 self.bold속성을 신설.

**How Has This Been Tested?**

```python
{'_text': '인',
 'matrix': (10.08, 0.0, 0.0, 10.08, 82.34400000000001, 688.50712),
 'fontname': 'AAAAEC+Batang',
 'adv': 1.0,
 'bold': False, # <----- bold 항목 작동 확인
 'upright': True,
 'x0': 82.34400000000001,
 'y0': 688.50712,
 'x1': 92.424,
 'y1': 698.58712,
 'width': 10.079999999999998,
 'height': 10.080000000000041,
 'bbox': (82.34400000000001, 688.50712, 92.424, 698.58712),
 'size': 10.080000000000041},


{'_text': 'w',
 'matrix': (1, 0, 0.21256, 1.0, 250.22, 10.0),
 'fontname': 'RCEAXX+New Gulim',
 'adv': 9.0,
 'bold': True, # <------ bold
 'upright': True,
 'x0': 250.22,
 'y0': 10.0,
 'x1': 261.77072,
 'y1': 22.0,
 'width': 11.550719999999984,
 'height': 12.0,
 'bbox': (250.22, 10.0, 261.77072, 22.0),
 'size': 12.0}
```


